### PR TITLE
allow using kakadu for image processing. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,7 @@ Features
 #. Attempts to recognize running headers, footers, and decimal or page numbers.
    Level of confidence in fuzzy matching can be fine tuned in ``config.ini``.
    Errs on the side of minimizing false positives.
+#. Will use Kakadu image libraries if present, otherwise will fall back to Pillow.
 
 Limitations
 ===========
@@ -37,6 +38,7 @@ Requirements
 * Python 3
 * If running epubcheck, a Java Runtime environment
 * If running DAISY Ace, Node.js
+* If using Kakadu, `install the binaries <http://kakadusoftware.com/downloads/>`_ and add the your  PATH and LD_LIBRARY_PATH
 
 Usage
 =====

--- a/abbyy_to_epub3/create_epub.py
+++ b/abbyy_to_epub3/create_epub.py
@@ -311,7 +311,9 @@ class Ebook(object):
             epubimage.content = f.read()
         epubimage = self.book.add_item(epubimage)
 
-        container_w = width / pagewidth * 100
+        # to approximate original layout, set the image container width to
+        # percentage of the page width
+        container_w = (width / pagewidth) * 100
         content = u'''
         <div style="width: {c_w}%;">
         <img src="{src}" alt="Picture #{picnum}">

--- a/abbyy_to_epub3/image_processing.py
+++ b/abbyy_to_epub3/image_processing.py
@@ -107,7 +107,7 @@ def factory(type):
             Pagedim isn't used for Pillow processing but it's passed anyway
             because the caller doesn't know which library we use.
             """
-            
+
             if dim:
                 # if dimensions are passed, save a crop of the image
                 try:

--- a/abbyy_to_epub3/image_processing.py
+++ b/abbyy_to_epub3/image_processing.py
@@ -1,0 +1,127 @@
+# Copyright 2017 Deborah Kaplan
+#
+# This file is part of Abbyy-to-epub3.
+# Source code is available at <https://github.com/deborahgu/abbyy-to-epub3>.
+#
+# Abbyy-to-epub3 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from PIL import Image
+
+import logging
+import subprocess
+
+
+class ImageProcessor(object):
+    """
+    The image object.
+
+    Can use various image processing libraries via factories.
+    """
+    def __init__(self, debug=False):
+        self.logger = logging.getLogger(__name__)
+        if debug:
+            self.logger.addHandler(logging.StreamHandler())
+            self.logger.setLevel(logging.DEBUG)
+
+
+def factory(type):
+
+    class KakaduProcessor(ImageProcessor):
+        def crop_image(self, origfile, outfile, dim=False, pagedim=False):
+            """
+            Given an image object, save a crop of the entire image.
+            """
+            
+            if dim:
+                # if dimensions are passed, save a crop of the image
+
+                # convert the dimensions we have
+                #   (left, top, right, bottom) in pixels
+                # to the format wanted by kakadu
+                #   "{<top>,<left>},{<height>,<width>}"
+                # as percentages between 0.0 and 1.0
+                # pagedim is passed as (width, height)
+
+                if not pagedim:
+                    self.logger.warning(
+                        "Can't crop in Kakadu without page dimensions"
+                    )
+                    return
+
+                (left, top, right, bottom) = dim
+                (pagewidth, pageheight) = pagedim
+                region_string = "{%s,%s},{%s,%s}" % (
+                    top / pageheight,
+                    left / pagewidth,
+                    (bottom - top) / pageheight,
+                    (right - left) / pagewidth
+                )
+
+                cmd = [
+                    'kdu_expand',
+                    '-region', region_string,
+                    '-i', origfile,
+                    '-o', outfile
+                ]
+
+                try:
+                    subprocess.run(cmd, stdout=subprocess.DEVNULL, check=True)
+                except subprocess.CalledProcessError as e:
+                    self.logger.warning(
+                        "Can't save cropped image: {}".format(e)
+                    )
+            else:
+                # save the entire image
+                try:
+                    Image.open(origfile).save(outfile)
+                except IOError as e:
+                    self.logger.warning(
+                        "Cannot create cover file: {}".format(e)
+                    )
+
+    class PillowProcessor(ImageProcessor):
+
+        def crop_image(self, origfile, outfile, dim=False, pagedim=False):
+            """
+            Given an image object, save a crop or the entire image.
+            Pagedim isn't used for Pillow processing but it's passed anyway
+            because the caller doesn't know which library we use.
+            """
+            
+            if dim:
+                # if dimensions are passed, save a crop of the image
+                try:
+                    i = Image.open(origfile)
+                except IOError as e:
+                    print("Can't open image {}: {}".format(origfile, e))
+                try:
+                    i.crop(dim).save(outfile)
+                except IOError as e:
+                    self.logger.warning(
+                        "Can't crop image {} & save to {}: {}".format(
+                            origfile, outfile, e
+                        )
+                    )
+            else:
+                # save the entire image
+                try:
+                    Image.open(origfile).save(outfile)
+                except IOError as e:
+                    self.logger.warning(
+                        "Cannot create cover file: {}".format(e)
+                    )
+
+    if type == "kakadu":
+        return KakaduProcessor()
+    return PillowProcessor()

--- a/abbyy_to_epub3/parse_abbyy.py
+++ b/abbyy_to_epub3/parse_abbyy.py
@@ -264,7 +264,9 @@ class AbbyyParser(object):
                 'mainFontStyleId' in attribs and
                 'mainFontStyleId' in self.fontStyles
             ):
-                    self.paragraphs[id]['fontstyle'] = self.fontStyles['mainFontStyleId']
+                    self.paragraphs[id]['fontstyle'] = self.fontStyles[
+                        'mainFontStyleId'
+                    ]
 
         elif (
             elem.tag == "{{{}}}page".format(self.ns) or
@@ -352,6 +354,9 @@ class AbbyyParser(object):
                         self.blocks.append(d)
                         d = dict()
 
+                        para.clear()  # garbage collection
+                    del paras         # garbage collection
+
                 elif self.is_block_type(block, "Table"):
                     # We'll process the table by treating each of its cells
                     # subordinate blocks as separate. Keep track of which
@@ -419,8 +424,12 @@ class AbbyyParser(object):
                                 d = dict()
                                 if newpage:
                                     newpage = False
+                            cell.clear()        # garbage collection
+                        del cells               # garbage collection
+                        row.clear()             # garbage collection
+                    del rows                    # garbage collection
                 else:
-                    # Create an entry for non-text blocks with type & attributes
+                    # Create entry for non-text blocks with type & attributes
                     d = {
                         'type': block.get("blockType"),
                         'style': blockattr,

--- a/abbyy_to_epub3/tests/test_image_processing.py
+++ b/abbyy_to_epub3/tests/test_image_processing.py
@@ -1,0 +1,140 @@
+﻿# -*- coding: utf-8 -*-
+# Copyright 2017 Deborah Kaplan
+#
+# This file is part of Abbyy-to-epub3.
+# Source code is available at <https://github.com/deborahgu/abbyy-to-epub3>.
+#
+# Abbyy-to-epub3 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from PIL import Image
+
+import mock
+import subprocess
+
+from abbyy_to_epub3.image_processing import factory as ImageFactory
+
+
+class TestImageFactory(object):
+
+    #
+    # Image instantiation tests
+    #
+    def test_create_kakadu_image(self):
+        """ Create an ImageProcessor object with type kakadu """
+        # Because the image library factories are defined as local subclasses
+        # of the factory function, "isinstance()" can't verify them. Check the
+        # type with this hack instead.
+        typestring = "KakaduProcessor"
+
+        test_image = ImageFactory("kakadu")
+
+        assert typestring in str(type(test_image))
+
+    def test_create_pillow_image(self):
+        """ Create an ImageProcessor object with type pillow """
+        # Because the image library factories are defined as local subclasses
+        # of the factory function, "isinstance()" can't verify them. Check the
+        # type with this hack instead.
+        typestring = "PillowProcessor"
+
+        test_image = ImageFactory("pillow")
+
+        assert typestring in str(type(test_image))
+
+    #
+    # Kakadu tests
+    #
+    @mock.patch("subprocess.run")
+    def test_kakadu_uncropped_subprocess(self, mock_subprocess):
+        """
+        When working with Kakadu, a call to crop_image with no dimensions
+        makes the subprocess call without a region string.
+        """
+        test_image = ImageFactory("kakadu")
+        infile = 'input_filename'
+        outfile = 'output_filename'
+        expected = [
+            'kdu_expand', '-i', 'input_filename', '-o', 'output_filename'
+        ]
+
+        test_image.crop_image(infile, outfile)
+        mock_subprocess.assert_called_with(
+            (expected), stdout=subprocess.DEVNULL, check=True
+        )
+
+    @mock.patch("subprocess.run")
+    def test_kakadu_cropped_subprocess(self, mock_subprocess):
+        """
+        When working with Kakadu, a call to crop_image with provided
+        dimensions makes the subprocess call with a region string.
+        """
+        test_image = ImageFactory("kakadu")
+        infile = 'input_filename'
+        outfile = 'output_filename'
+        dim = [1, 2, 3, 4]
+        pagedim = (1.0, 2.0)
+
+        expected = [
+            'kdu_expand',
+            '-region', '{1.0,1.0},{1.0,2.0}',
+            '-i', 'input_filename',
+            '-o', 'output_filename',
+        ]
+
+        test_image.crop_image(infile, outfile, dim=dim, pagedim=pagedim)
+        mock_subprocess.assert_called_with(
+            (expected), stdout=subprocess.DEVNULL, check=True
+        )
+
+    #
+    # Pillow tests
+    #
+    def test_pillow_uncropped(self):
+        """
+        When working with Pillow, a call to crop_image with no dimensions
+        makes the call to save.
+        """
+        with mock.patch.object(Image, "open") as MockImage:
+            test_image = ImageFactory("pillow")
+            infile = 'input_filename'
+            outfile = 'output_filename'
+            expected = MockImage.save(outfile)
+
+            test_image.crop_image(infile, outfile)
+
+            # Did we open the file?
+            MockImage.assert_called_with(infile)
+            # Did we save the file?
+            MockImage.assert_has_calls(expected)
+
+    def test_pillow_cropped(self):
+        """
+        When working with Pillow, a call to crop_image with provided
+        dimensions makes the call to crop.
+        """
+        with mock.patch.object(Image, "open") as MockImage:
+            test_image = ImageFactory("pillow")
+            infile = 'input_filename'
+            outfile = 'output_filename'
+            dim = [1, 2, 3, 4]
+            pagedim = (1.0, 2.0)
+
+            expected = MockImage.crop(infile, dim)
+
+            test_image.crop_image(infile, outfile, dim=dim, pagedim=pagedim)
+
+            # Did we open the file?
+            MockImage.assert_called_with(infile)
+            # Did we save the file?
+            MockImage.assert_has_calls(expected)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 epubcheck>=0.3.1
 fuzzywuzzy[speedup]>=0.15.1
 lxml==3.8.0
+mock>=2.0.0
 pillow==4.2.1
 PyExecJs>=1.4.1
 pytest>=3.2.2

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'epubcheck',
         'fuzzywuzzy',
         'lxml',
+        'mock',
         'Pillow',
         'PyExecJs',
         'pytest',


### PR DESCRIPTION
 Since Kakadu isn't a python module or a package we can set as an auto install, have a sensible fallback to Pillow. This requires switching to bmp for image format, because Kakadu doesn't handle PNGs. The resulting epub is rather large, but the processing has speeded up.