### PR TITLE
fixes #39 switches to converting all images to PNG, 

### DIFF
--- a/abbyy_to_epub3/create_epub.py
+++ b/abbyy_to_epub3/create_epub.py
@@ -363,7 +363,7 @@ class Ebook(ArchiveBookItem):
         the image HTML
         """
         page_no = block['page_no']
-        if page_no == 1:
+        if page_no == 0:
             # The first page's image is made into the cover automatically
             return
 
@@ -371,9 +371,11 @@ class Ebook(ArchiveBookItem):
         origfile = '{dir}/{item_bookpath}_jp2/{item_bookpath}_{page:0>4}.jp2'.format(
             dir=self.tmpdir,
             item_bookpath=self.item_bookpath,
-            page=block['page_no']
+            page=page_no
         )
-        basefile = 'img_{:0>4}.bmp'.format(self.picnum)
+        if not os.path.isfile(origfile):
+            return
+        basefile = 'img_{:0>4}.png'.format(self.picnum)
         outfile = '{}/{}'.format(self.tmpdir, basefile)
         in_epub_imagefile = 'images/{}'.format(basefile)
 
@@ -982,7 +984,7 @@ class Ebook(ArchiveBookItem):
         # Even if we clean up properly afterwards, using TemporaryDirectory
         # outside of a convtext manager seems to cause a resource leak
         with tempfile.TemporaryDirectory() as self.tmpdir:
-            self.cover_img = '{}/cover.bmp'.format(self.tmpdir)
+            self.cover_img = '{}/cover.png'.format(self.tmpdir)
             self.abbyy_file = "{tmp}/{base}_abbyy".format(
                 tmp=self.tmpdir, base=self.item_identifier
             )
@@ -1034,7 +1036,7 @@ class Ebook(ArchiveBookItem):
 
             # Set the book's cover
             self.book.set_cover(
-                'images/cover.bmp',
+                'images/cover.png',
                 open(self.cover_img, 'rb').read()
             )
             cover = self.book.items[-1]

--- a/abbyy_to_epub3/image_processing.py
+++ b/abbyy_to_epub3/image_processing.py
@@ -41,60 +41,73 @@ def factory(type):
         def crop_image(self, origfile, outfile, dim=False, pagedim=False):
             """
             Given an image object, save a crop of the entire image.
+            Convert (left, top, right, bottom) in pixels to the format
+            wanted by kakadu: "{<top>,<left>},{<height>,<width>}"
+            as percentages between 0.0 and 1.0.
+            Pagedim is passed as (width, height)
             """
-            
-            if dim:
-                # if dimensions are passed, save a crop of the image
-                if pagedim:
-                    """
-                    Convert (left, top, right, bottom) in pixels to the format
-                    wanted by kakadu: "{<top>,<left>},{<height>,<width>}"
-                    as percentages between 0.0 and 1.0.
-                    Pagedim is passed as (width, height)
-                    """
-                    (left, top, right, bottom) = dim
-                    (pagewidth, pageheight) = pagedim
-                    region_string = "{%s,%s},{%s,%s}" % (
-                        top / pageheight,
-                        left / pagewidth,
-                        (bottom - top) / pageheight,
-                        (right - left) / pagewidth
-                    )
 
-                    # kdu_expand has to be run as a subprocess call
-                    cmd = [
-                        'kdu_expand',
-                        '-region', region_string,
-                        '-i', origfile,
-                        '-o', outfile
-                    ]
-                    try:
-                        subprocess.run(
-                            cmd, stdout=subprocess.DEVNULL, check=True
-                        )
-                    except subprocess.CalledProcessError as e:
-                        raise RuntimeError(
-                            "Can't save cropped image: {}".format(e)
-                        )
-                else:
-                    raise RuntimeError(
-                        "Can't crop in Kakadu without page dimensions"
-                    )
+            if dim and pagedim:
+                # if dimensions are passed, save a crop of the image
+                (left, top, right, bottom) = dim
+                (pagewidth, pageheight) = pagedim
+                region_string = "{%s,%s},{%s,%s}" % (
+                    top / pageheight,
+                    left / pagewidth,
+                    (bottom - top) / pageheight,
+                    (right - left) / pagewidth
+                )
             else:
-                # without dimensions, save the entire uncropped image
-                cmd = [
-                    'kdu_expand',
-                    '-i', origfile,
-                    '-o', outfile
-                ]
-                try:
-                    subprocess.run(
-                        cmd, stdout=subprocess.DEVNULL, check=True
-                    )
-                except subprocess.CalledProcessError as e:
-                    raise RuntimeError(
-                        "Can't open image {}: {}".format(origfile, e)
-                    )
+                region_string = "{0.0,0.0},{1.0,1.0}"
+
+            # kdu_expand has to be run as a subprocess call
+            cmd_bmp = [
+                'kdu_expand',
+                '-region', region_string,
+                '-i', origfile,
+                '-o', outfile + '.bmp'
+            ]
+            cmd_pnm = [
+                'bmptopnm', outfile + '.bmp'
+            ]
+            cmd_png = 'pnmtopng'
+            try:
+                subprocess.run(
+                    cmd_bmp, stdout=subprocess.DEVNULL, check=True
+                )
+            except subprocess.CalledProcessError as e:
+                raise RuntimeError(
+                    "Can't save cropped image as BMP: {}".format(e)
+                )
+            # We don't always control the filenames of the JP2, so use
+            # subprocess.PIPE, not shell=True, to prevent injection
+            try:
+                p_pnm = subprocess.Popen(
+                    cmd_pnm,
+                    stderr=subprocess.DEVNULL,
+                    stdout=subprocess.PIPE,
+                )
+            except subprocess.CalledProcessError as e:
+                raise RuntimeError(
+                    "Can't generate PNM: {}".format(e)
+                )
+            try:
+                p_png = subprocess.Popen(
+                    cmd_png,
+                    stderr=subprocess.DEVNULL,
+                    stdin=p_pnm.stdout,
+                    stdout=subprocess.PIPE,
+                )
+            except subprocess.CalledProcessError as e:
+                raise RuntimeError(
+                    "Can't generate PNG: {}".format(e)
+                )
+
+            # Write the PNG from the pipeline into a file
+            # `pnmtopng` only writes to stdout
+            pngout, pngerr = p_png.communicate()
+            with open(outfile, 'wb') as fh:
+                fh.write(pngout)
 
     class PillowProcessor(ImageProcessor):
 

--- a/abbyy_to_epub3/parse_abbyy.py
+++ b/abbyy_to_epub3/parse_abbyy.py
@@ -286,7 +286,7 @@ class AbbyyParser(object):
 
     def parse_content(self):
         """ Parse each page of the book.  """
-        page_no = 1
+        page_no = 0
         d = {'page_no': page_no}
 
         self.pages[0].clear()    # clear the memory first


### PR DESCRIPTION
for epub 3.1 compatibility and smaller file size. Re-factors Kakadu processing to be simpler. Fixes an image numbering issue.